### PR TITLE
Fix TemporalCalendarString ambiguity

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1213,10 +1213,9 @@
       TemporalZonedDateTimeString :
           Date TimeSpecSeparator? TimeZoneNameRequired Calendar?
 
-      ISODateTimeString :
+      TemporalCalendarString :
+          CalendarDateTime
           TemporalInstantString
-          TemporalDateTimeString
-          TemporalZonedDateTimeString
           CalendarTime
           DateSpecYearMonth
           DateSpecMonthDay
@@ -1241,8 +1240,9 @@
     <emu-note>The value of ! ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
     <emu-alg>
       1. Let _parseResult_ be ~empty~.
-      1. Set _parseResult_ to ParseText(StringToCodePoints(_isoString_), |ISODateTimeString|).
-      1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
+      1. For each nonterminal _goal_ of &laquo; |TemporalDateTimeString|, |TemporalInstantString|, |TemporalMonthDayString|, |TemporalTimeString|, |TemporalYearMonthString|, |TemporalZonedDateTimeString| &raquo;, do
+        1. If _parseResult_ is not a Parse Node, set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
+      1. Assert: _parseResult_ is a Parse Node.
       1. Let each of _year_, _month_, _day_, _hour_, _minute_, _second_, _fSeconds_, and _calendar_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, |TimeFraction|, and |CalendarName| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
       1. If the first code point of _year_ is U+2212 (MINUS SIGN), replace the first code point with U+002D (HYPHEN-MINUS).
       1. Let _yearMV_ be ! ToIntegerOrInfinity(CodePointsToString(_year_)).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1213,10 +1213,10 @@
       TemporalZonedDateTimeString :
           Date TimeSpecSeparator? TimeZoneNameRequired Calendar?
 
-      TemporalCalendarString :
-          CalendarName
+      ISODateTimeString :
           TemporalInstantString
-          CalendarDateTime
+          TemporalDateTimeString
+          TemporalZonedDateTimeString
           CalendarTime
           DateSpecYearMonth
           DateSpecMonthDay
@@ -1241,9 +1241,8 @@
     <emu-note>The value of ! ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
     <emu-alg>
       1. Let _parseResult_ be ~empty~.
-      1. For each nonterminal _goal_ of &laquo; |TemporalDateTimeString|, |TemporalInstantString|, |TemporalMonthDayString|, |TemporalTimeString|, |TemporalYearMonthString|, |TemporalZonedDateTimeString| &raquo;, do
-        1. If _parseResult_ is not a Parse Node, set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
-      1. Assert: _parseResult_ is a Parse Node.
+      1. Set _parseResult_ to ParseText(StringToCodePoints(_isoString_), |ISODateTimeString|).
+      1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
       1. Let each of _year_, _month_, _day_, _hour_, _minute_, _second_, _fSeconds_, and _calendar_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, |TimeFraction|, and |CalendarName| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
       1. If the first code point of _year_ is U+2212 (MINUS SIGN), replace the first code point with U+002D (HYPHEN-MINUS).
       1. Let _yearMV_ be ! ToIntegerOrInfinity(CodePointsToString(_year_)).
@@ -1370,12 +1369,14 @@
       <dd>It parses the argument as an ISO 8601 string and returns the calendar identifier, or *undefined* if there is none.</dd>
     </dl>
     <emu-alg>
-      1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalCalendarString|).
-      1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. Let _id_ be the source text matched by the |CalendarName| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
-      1. If _id_ is empty, then
+      1. Let _calendar_ be ~empty~.
+      1. Set _calendar_ to ? ParseISODateTime(_isoString_).[[calendar]].
+      1. If _calendar_ is not *undefined*, return _calendar_.
+      1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |CalendarName|).
+      1. Set _calendar_ to the source text matched by the |CalendarName| Parse Node, or an empty sequence of code points if not present.
+      1. If _calendar_ is empty, then
         1. Return *"iso8601"*.
-      1. Return CodePointsToString(_id_).
+      1. Return CodePointsToString(_calendar_).
     </emu-alg>
   </emu-clause>
 


### PR DESCRIPTION
I have a question on this:
Q When does `ParseText(...)` return a List of errors? (The spec text says it checks for 'early errors', but I didn't quite understand what that meant)
 