### PR TITLE
Fix generating durations from non-numeric inputs

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1630,8 +1630,9 @@
       <dd>It converts _argument_ to an integer representing its Number value (replacing *NaN* with 0), or throws a *RangeError* when that Number value is not a finite integral Number.</dd>
     </dl>
     <emu-alg>
+      1. If _argument_ is *undefined*, return 0.
       1. Let _number_ be ? ToNumber(_argument_).
-      1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return 0.
+      1. If _number_ is *-0*<sub>𝔽</sub>, return 0.
       1. If IsIntegralNumber(_number_) is *false*, throw a *RangeError* exception.
       1. Return ℝ(_number_).
     </emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1421,31 +1421,31 @@
       1. Let _duration_ be ParseText(StringToCodePoints(_isoString_), |TemporalDurationString|).
       1. If _duration_ is a List of errors, throw a *RangeError* exception.
       1. Let each of _sign_, _years_, _months_, _weeks_, _days_, _hours_, _fHours_, _minutes_, _fMinutes_, _seconds_, and _fSeconds_ be the source text matched by the respective |Sign|, |DurationYears|, |DurationMonths|, |DurationWeeks|, |DurationDays|, |DurationWholeHours|, |DurationHoursFraction|, |DurationWholeMinutes|, |DurationMinutesFraction|, |DurationWholeSeconds|, and |DurationSecondsFraction| Parse Node contained within _duration_, or an empty sequence of code points if not present.
-      1. Let _yearsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_years_)).
-      1. Let _monthsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_months_)).
-      1. Let _weeksMV_ be ? ToIntegerWithTruncation(CodePointsToString(_weeks_)).
-      1. Let _daysMV_ be ? ToIntegerWithTruncation(CodePointsToString(_days_)).
-      1. Let _hoursMV_ be ? ToIntegerWithTruncation(CodePointsToString(_hours_)).
+      1. Let _yearsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_years_), *true*).
+      1. Let _monthsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_months_), *true*).
+      1. Let _weeksMV_ be ? ToIntegerWithTruncation(CodePointsToString(_weeks_), *true*).
+      1. Let _daysMV_ be ? ToIntegerWithTruncation(CodePointsToString(_days_), *true*).
+      1. Let _hoursMV_ be ? ToIntegerWithTruncation(CodePointsToString(_hours_), *true*).
       1. If _fHours_ is not empty, then
         1. If any of _minutes_, _fMinutes_, _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fHoursDigits_ be the substring of CodePointsToString(_fHours_) from 1.
         1. Let _fHoursScale_ be the length of _fHoursDigits_.
-        1. Let _minutesMV_ be ? ToIntegerWithTruncation(_fHoursDigits_) / 10<sup>_fHoursScale_</sup> &times; 60.
+        1. Let _minutesMV_ be ? ToIntegerWithTruncation(_fHoursDigits_, *true*) / 10<sup>_fHoursScale_</sup> &times; 60.
       1. Else,
-        1. Let _minutesMV_ be ? ToIntegerWithTruncation(CodePointsToString(_minutes_)).
+        1. Let _minutesMV_ be ? ToIntegerWithTruncation(CodePointsToString(_minutes_), *true*).
       1. If _fMinutes_ is not empty, then
         1. If any of _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fMinutesDigits_ be the substring of CodePointsToString(_fMinutes_) from 1.
         1. Let _fMinutesScale_ be the length of _fMinutesDigits_.
-        1. Let _secondsMV_ be ? ToIntegerWithTruncation(_fMinutesDigits_) / 10<sup>_fMinutesScale_</sup> &times; 60.
+        1. Let _secondsMV_ be ? ToIntegerWithTruncation(_fMinutesDigits_, *true*) / 10<sup>_fMinutesScale_</sup> &times; 60.
       1. Else if _seconds_ is not empty, then
-        1. Let _secondsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_seconds_)).
+        1. Let _secondsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_seconds_), *true*).
       1. Else,
         1. Let _secondsMV_ be remainder(_minutesMV_, 1) &times; 60.
       1. If _fSeconds_ is not empty, then
         1. Let _fSecondsDigits_ be the substring of CodePointsToString(_fSeconds_) from 1.
         1. Let _fSecondsScale_ be the length of _fSecondsDigits_.
-        1. Let _millisecondsMV_ be ? ToIntegerWithTruncation(_fSecondsDigits_) / 10<sup>_fSecondsScale_</sup> &times; 1000.
+        1. Let _millisecondsMV_ be ? ToIntegerWithTruncation(_fSecondsDigits_, *true*) / 10<sup>_fSecondsScale_</sup> &times; 1000.
       1. Else,
         1. Let _millisecondsMV_ be remainder(_secondsMV_, 1) &times; 1000.
       1. Let _microsecondsMV_ be remainder(_millisecondsMV_, 1) &times; 1000.
@@ -1589,7 +1589,7 @@
       <dd>It converts _argument_ to an integer representing its Number value with fractional part truncated (replacing *NaN* with 0), or throws a *RangeError* when that Number value is not finite or not positive.</dd>
     </dl>
     <emu-alg>
-      1. Let _integer_ be ? ToIntegerWithTruncation(_argument_).
+      1. Let _integer_ be ? ToIntegerWithTruncation(_argument_, *false*).
       1. If _integer_ &le; 0, throw a *RangeError* exception.
       1. Return _integer_.
     </emu-alg>
@@ -1599,6 +1599,7 @@
     <h1>
       ToIntegerWithTruncation (
         _argument_: an ECMAScript language value,
+        _isOptional_: a Boolean value to indicate whether the argument is optional,
       ): either a normal completion containing an integer, or an abrupt completion
     </h1>
     <dl class="header">
@@ -1606,10 +1607,15 @@
       <dd>It converts _argument_ to an integer representing its Number value with fractional part truncated (replacing *NaN* with 0), or throws a *RangeError* when that Number value is not finite.</dd>
     </dl>
     <emu-alg>
+      1. If _argument_ is *undefined*, then
+        1. If _isOptional_ is *true*, return 0.
+        1. Throw a *RangeError* exception.
       1. Let _number_ be ? ToNumber(_argument_).
-      1. If _number_ is *NaN*, return 0.
-      1. If _number_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
-      1. Return truncate(ℝ(number)).
+      1. If _number_ is *NaN*, -∞, or +∞, throw a *RangeError* exception.
+      1. If _number_ is *-0*<sub>𝔽</sub>, return 0.
+      1. Let _integer_ be floor(abs(ℝ(_number_))).
+      1. If _number_ < *-0*<sub>𝔽</sub>, set _integer_ to -_integer_.
+      1. Return _integer_.
     </emu-alg>
   </emu-clause>
 
@@ -1657,7 +1663,7 @@
           1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
             1. Let _Conversion_ be the Conversion value of the same row.
             1. If _Conversion_ is ~ToIntegerWithTruncation~, then
-              1. Set _value_ to ? ToIntegerWithTruncation(_value_).
+              1. Set _value_ to ? ToIntegerWithTruncation(_value_, *true*).
               1. Set _value_ to 𝔽(_value_).
             1. Else if _Conversion_ is ~ToPositiveIntegerWithTruncation~, then
               1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1421,31 +1421,31 @@
       1. Let _duration_ be ParseText(StringToCodePoints(_isoString_), |TemporalDurationString|).
       1. If _duration_ is a List of errors, throw a *RangeError* exception.
       1. Let each of _sign_, _years_, _months_, _weeks_, _days_, _hours_, _fHours_, _minutes_, _fMinutes_, _seconds_, and _fSeconds_ be the source text matched by the respective |Sign|, |DurationYears|, |DurationMonths|, |DurationWeeks|, |DurationDays|, |DurationWholeHours|, |DurationHoursFraction|, |DurationWholeMinutes|, |DurationMinutesFraction|, |DurationWholeSeconds|, and |DurationSecondsFraction| Parse Node contained within _duration_, or an empty sequence of code points if not present.
-      1. Let _yearsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_years_), *true*).
-      1. Let _monthsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_months_), *true*).
-      1. Let _weeksMV_ be ? ToIntegerWithTruncation(CodePointsToString(_weeks_), *true*).
-      1. Let _daysMV_ be ? ToIntegerWithTruncation(CodePointsToString(_days_), *true*).
-      1. Let _hoursMV_ be ? ToIntegerWithTruncation(CodePointsToString(_hours_), *true*).
+      1. If _yearsMV_ is *undefined*, let _yearsMV_ be *+0*<sub>𝔽</sub>; else let _yearsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_years_)).
+      1. If _monthsMV_ is *undefined*, let _monthsMV_ be *+0*<sub>𝔽</sub>; else let _monthsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_months_)).
+      1. If _weeksMV_ is *undefined*, let _weeksMV_ be *+0*<sub>𝔽</sub>; else let _weeksMV_ be ? ToIntegerWithTruncation(CodePointsToString(_weeks_)).
+      1. If _daysMV_ is *undefined*, let _daysMV_ be *+0*<sub>𝔽</sub>; else let _daysMV_ be ? ToIntegerWithTruncation(CodePointsToString(_days_)).
+      1. If _hoursMV_ is *undefined*, let _hoursMV_ be *+0*<sub>𝔽</sub>; else let _hoursMV_ be ? ToIntegerWithTruncation(CodePointsToString(_hours_)).
       1. If _fHours_ is not empty, then
         1. If any of _minutes_, _fMinutes_, _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fHoursDigits_ be the substring of CodePointsToString(_fHours_) from 1.
         1. Let _fHoursScale_ be the length of _fHoursDigits_.
-        1. Let _minutesMV_ be ? ToIntegerWithTruncation(_fHoursDigits_, *true*) / 10<sup>_fHoursScale_</sup> &times; 60.
+        1. If _minutesMV_ is *undefined*, let _minutesMV_ be *+0*<sub>𝔽</sub>; else let _minutesMV_ be ? ToIntegerWithTruncation(_fHoursDigits_) / 10<sup>_fHoursScale_</sup> &times; 60.
       1. Else,
-        1. Let _minutesMV_ be ? ToIntegerWithTruncation(CodePointsToString(_minutes_), *true*).
+        1. If _minutesMV_ is *undefined*, let _minutesMV_ be *+0*<sub>𝔽</sub>; else let _minutesMV_ be ? ToIntegerWithTruncation(CodePointsToString(_minutes_)).
       1. If _fMinutes_ is not empty, then
         1. If any of _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fMinutesDigits_ be the substring of CodePointsToString(_fMinutes_) from 1.
         1. Let _fMinutesScale_ be the length of _fMinutesDigits_.
-        1. Let _secondsMV_ be ? ToIntegerWithTruncation(_fMinutesDigits_, *true*) / 10<sup>_fMinutesScale_</sup> &times; 60.
+        1. If _secondsMV_ is *undefined*, let _secondsMV_ be *+0*<sub>𝔽</sub>; else let _secondsMV_ be ? ToIntegerWithTruncation(_fMinutesDigits_) / 10<sup>_fMinutesScale_</sup> &times; 60.
       1. Else if _seconds_ is not empty, then
-        1. Let _secondsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_seconds_), *true*).
+        1. If _secondsMV_ is *undefined*, let _secondsMV_ be *+0*<sub>𝔽</sub>; else let _secondsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_seconds_)).
       1. Else,
         1. Let _secondsMV_ be remainder(_minutesMV_, 1) &times; 60.
       1. If _fSeconds_ is not empty, then
         1. Let _fSecondsDigits_ be the substring of CodePointsToString(_fSeconds_) from 1.
         1. Let _fSecondsScale_ be the length of _fSecondsDigits_.
-        1. Let _millisecondsMV_ be ? ToIntegerWithTruncation(_fSecondsDigits_, *true*) / 10<sup>_fSecondsScale_</sup> &times; 1000.
+        1. If _millisecondsMV_ is *undefined*, let _millisecondsMV_ be *+0*<sub>𝔽</sub>; else let _millisecondsMV_ be ? ToIntegerWithTruncation(_fSecondsDigits_) / 10<sup>_fSecondsScale_</sup> &times; 1000.
       1. Else,
         1. Let _millisecondsMV_ be remainder(_secondsMV_, 1) &times; 1000.
       1. Let _microsecondsMV_ be remainder(_millisecondsMV_, 1) &times; 1000.
@@ -1589,7 +1589,7 @@
       <dd>It converts _argument_ to an integer representing its Number value with fractional part truncated (replacing *NaN* with 0), or throws a *RangeError* when that Number value is not finite or not positive.</dd>
     </dl>
     <emu-alg>
-      1. Let _integer_ be ? ToIntegerWithTruncation(_argument_, *false*).
+      1. Let _integer_ be ? ToIntegerWithTruncation(_argument_).
       1. If _integer_ &le; 0, throw a *RangeError* exception.
       1. Return _integer_.
     </emu-alg>
@@ -1599,7 +1599,6 @@
     <h1>
       ToIntegerWithTruncation (
         _argument_: an ECMAScript language value,
-        _isOptional_: a Boolean value to indicate whether the argument is optional,
       ): either a normal completion containing an integer, or an abrupt completion
     </h1>
     <dl class="header">
@@ -1607,9 +1606,7 @@
       <dd>It converts _argument_ to an integer representing its Number value with fractional part truncated (replacing *NaN* with 0), or throws a *RangeError* when that Number value is not finite.</dd>
     </dl>
     <emu-alg>
-      1. If _argument_ is *undefined*, then
-        1. If _isOptional_ is *true*, return 0.
-        1. Throw a *RangeError* exception.
+      1. If _argument_ is *undefined*, throw a *RangeError* exception.
       1. Let _number_ be ? ToNumber(_argument_).
       1. If _number_ is *NaN*, -∞, or +∞, throw a *RangeError* exception.
       1. If _number_ is *-0*<sub>𝔽</sub>, return 0.
@@ -1664,7 +1661,7 @@
           1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
             1. Let _Conversion_ be the Conversion value of the same row.
             1. If _Conversion_ is ~ToIntegerWithTruncation~, then
-              1. Set _value_ to ? ToIntegerWithTruncation(_value_, *true*).
+              1. Set _value_ to ? ToIntegerWithTruncation(_value_).
               1. Set _value_ to 𝔽(_value_).
             1. Else if _Conversion_ is ~ToPositiveIntegerWithTruncation~, then
               1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).
@@ -1683,10 +1680,6 @@
         1. Throw a *TypeError* exception.
       1. Return _result_.
     </emu-alg>
-    <emu-note>
-      The value of ! ToIntegerWithTruncation(*undefined*) is 0.
-      ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.
-    </emu-note>
     <emu-table id="table-temporal-field-requirements">
       <emu-caption>Temporal field requirements</emu-caption>
       <table class="real-table">

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -157,7 +157,7 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"year"*, « _dateLike_ »).
-        1. Return ? ToIntegerWithTruncation(_result_, *false*).
+        1. Return ? ToIntegerWithTruncation(_result_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -157,8 +157,7 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"year"*, « _dateLike_ »).
-        1. If _result_ is *undefined*, throw a *RangeError* exception.
-        1. Return ? ToIntegerWithTruncation(_result_).
+        1. Return ? ToIntegerWithTruncation(_result_, *false*).
       </emu-alg>
     </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1385,7 +1385,7 @@
           <emu-alg>
             1. Assert: Type(_calendar_) is Object.
             1. Let _result_ be ? Invoke(_calendar_, *"eraYear"*, « _dateLike_ »).
-            1. If _result_ is not *undefined*, set _result_ to ? ToIntegerWithTruncation(_result_).
+            1. If _result_ is not *undefined*, set _result_ to ? ToIntegerWithTruncation(_result_, *true*).
             1. Return _result_.
           </emu-alg>
         </emu-clause>
@@ -2388,7 +2388,7 @@
               1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
                 1. Let _Conversion_ be the Conversion value of the same row.
                 1. If _Conversion_ is ~ToIntegerWithTruncation~, then
-                  1. Set _value_ to ? ToIntegerWithTruncation(_value_).
+                  1. Set _value_ to ? ToIntegerWithTruncation(_value_, *true*).
                   1. Set _value_ to 𝔽(_value_).
                 1. Else if _Conversion_ is ~ToPositiveIntegerWithTruncation~, then
                   1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1385,7 +1385,7 @@
           <emu-alg>
             1. Assert: Type(_calendar_) is Object.
             1. Let _result_ be ? Invoke(_calendar_, *"eraYear"*, « _dateLike_ »).
-            1. If _result_ is not *undefined*, set _result_ to ? ToIntegerWithTruncation(_result_, *true*).
+            1. If _result_ is not *undefined*, set _result_ to ? ToIntegerWithTruncation(_result_).
             1. Return _result_.
           </emu-alg>
         </emu-clause>
@@ -2388,7 +2388,7 @@
               1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
                 1. Let _Conversion_ be the Conversion value of the same row.
                 1. If _Conversion_ is ~ToIntegerWithTruncation~, then
-                  1. Set _value_ to ? ToIntegerWithTruncation(_value_, *true*).
+                  1. Set _value_ to ? ToIntegerWithTruncation(_value_).
                   1. Set _value_ to 𝔽(_value_).
                 1. Else if _Conversion_ is ~ToPositiveIntegerWithTruncation~, then
                   1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -32,9 +32,9 @@
       </p>
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_, *false*).
-        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_, *false*).
-        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_, *false*).
+        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
+        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
         1. Return ? CreateTemporalDate(_y_, _m_, _d_, _calendar_, NewTarget).
       </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -30,12 +30,11 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_).
-        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
-        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_).
+        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_, *false*).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_, *false*).
+        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_, *false*).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
         1. Return ? CreateTemporalDate(_y_, _m_, _d_, _calendar_, NewTarget).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -28,19 +28,18 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) for optional arguments is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _isoYear_ be ? ToIntegerWithTruncation(_isoYear_, *false*).
-        1. Let _isoMonth_ be ? ToIntegerWithTruncation(_isoMonth_, *false*).
-        1. Let _isoDay_ be ? ToIntegerWithTruncation(_isoDay_, *false*).
-        1. Let _hour_ be ? ToIntegerWithTruncation(_hour_, *true*).
-        1. Let _minute_ be ? ToIntegerWithTruncation(_minute_, *true*).
-        1. Let _second_ be ? ToIntegerWithTruncation(_second_, *true*).
-        1. Let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_, *true*).
-        1. Let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_, *true*).
-        1. Let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_, *true*).
+        1. Let _isoYear_ be ? ToIntegerWithTruncation(_isoYear_).
+        1. Let _isoMonth_ be ? ToIntegerWithTruncation(_isoMonth_).
+        1. Let _isoDay_ be ? ToIntegerWithTruncation(_isoDay_).
+        1. If _hour_ is *undefined*, let _hour_ be *+0*<sub>𝔽</sub>; else let _hour_ be ? ToIntegerWithTruncation(_hour_).
+        1. If _minute_ is *undefined*, let _minute_ be *+0*<sub>𝔽</sub>; else let _minute_ be ? ToIntegerWithTruncation(_minute_).
+        1. If _second_ is *undefined*, let _second_ be *+0*<sub>𝔽</sub>; else let _second_ be ? ToIntegerWithTruncation(_second_).
+        1. If _millisecond_ is *undefined*, let _millisecond_ be *+0*<sub>𝔽</sub>; else let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_).
+        1. If _microsecond_ is *undefined*, let _microsecond_ be *+0*<sub>𝔽</sub>; else let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_).
+        1. If _nanosecond_ is *undefined*, let _nanosecond_ be *+0*<sub>𝔽</sub>; else let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
         1. Return ? CreateTemporalDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_, NewTarget).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -28,19 +28,19 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) for optional arguments is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _isoYear_ be ? ToIntegerWithTruncation(_isoYear_).
-        1. Let _isoMonth_ be ? ToIntegerWithTruncation(_isoMonth_).
-        1. Let _isoDay_ be ? ToIntegerWithTruncation(_isoDay_).
-        1. Let _hour_ be ? ToIntegerWithTruncation(_hour_).
-        1. Let _minute_ be ? ToIntegerWithTruncation(_minute_).
-        1. Let _second_ be ? ToIntegerWithTruncation(_second_).
-        1. Let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_).
-        1. Let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_).
-        1. Let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_).
+        1. Let _isoYear_ be ? ToIntegerWithTruncation(_isoYear_, *false*).
+        1. Let _isoMonth_ be ? ToIntegerWithTruncation(_isoMonth_, *false*).
+        1. Let _isoDay_ be ? ToIntegerWithTruncation(_isoDay_, *false*).
+        1. Let _hour_ be ? ToIntegerWithTruncation(_hour_, *true*).
+        1. Let _minute_ be ? ToIntegerWithTruncation(_minute_, *true*).
+        1. Let _second_ be ? ToIntegerWithTruncation(_second_, *true*).
+        1. Let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_, *true*).
+        1. Let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_, *true*).
+        1. Let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_, *true*).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
         1. Return ? CreateTemporalDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_, NewTarget).
       </emu-alg>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -28,16 +28,16 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) for optional arguments is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. If _referenceISOYear_ is *undefined*, then
           1. Set _referenceISOYear_ to *1972*<sub>𝔽</sub>.
-        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
-        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_, *false*).
+        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_, *false*).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISOYear_).
+        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISOYear_, *true*).
         1. Return ? CreateTemporalMonthDay(_m_, _d_, _calendar_, _ref_, NewTarget).
       </emu-alg>
       <emu-note>1972 is the first leap year after the Unix epoch.</emu-note>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -28,16 +28,15 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) for optional arguments is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. If _referenceISOYear_ is *undefined*, then
           1. Set _referenceISOYear_ to *1972*<sub>𝔽</sub>.
-        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_, *false*).
-        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_, *false*).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
+        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISOYear_, *true*).
+        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISOYear_).
         1. Return ? CreateTemporalMonthDay(_m_, _d_, _calendar_, _ref_, NewTarget).
       </emu-alg>
       <emu-note>1972 is the first leap year after the Unix epoch.</emu-note>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -29,16 +29,15 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) for optional arguments is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _hour_ be ? ToIntegerWithTruncation(_hour_, *true*).
-        1. Let _minute_ be ? ToIntegerWithTruncation(_minute_, *true*).
-        1. Let _second_ be ? ToIntegerWithTruncation(_second_, *true*).
-        1. Let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_, *true*).
-        1. Let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_, *true*).
-        1. Let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_, *true*).
+        1. If _hour_ is *undefined*, let _hour_ be *+0*<sub>𝔽</sub>; else let _hour_ be ? ToIntegerWithTruncation(_hour_).
+        1. If _minute_ is *undefined*, let _minute_ be *+0*<sub>𝔽</sub>; else let _minute_ be ? ToIntegerWithTruncation(_minute_).
+        1. If _second_ is *undefined*, let _second_ be *+0*<sub>𝔽</sub>; else let _second_ be ? ToIntegerWithTruncation(_second_).
+        1. If _millisecond_ is *undefined*, let _millisecond_ be *+0*<sub>𝔽</sub>; else let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_).
+        1. If _microsecond_ is *undefined*, let _microsecond_ be *+0*<sub>𝔽</sub>; else let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_).
+        1. If _nanosecond_ is *undefined*, let _nanosecond_ be *+0*<sub>𝔽</sub>; else let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_).
         1. Return ? CreateTemporalTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, NewTarget).
       </emu-alg>
     </emu-clause>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -29,16 +29,16 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) for optional arguments is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _hour_ be ? ToIntegerWithTruncation(_hour_).
-        1. Let _minute_ be ? ToIntegerWithTruncation(_minute_).
-        1. Let _second_ be ? ToIntegerWithTruncation(_second_).
-        1. Let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_).
-        1. Let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_).
-        1. Let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_).
+        1. Let _hour_ be ? ToIntegerWithTruncation(_hour_, *true*).
+        1. Let _minute_ be ? ToIntegerWithTruncation(_minute_, *true*).
+        1. Let _second_ be ? ToIntegerWithTruncation(_second_, *true*).
+        1. Let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_, *true*).
+        1. Let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_, *true*).
+        1. Let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_, *true*).
         1. Return ? CreateTemporalTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, NewTarget).
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -28,16 +28,15 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) for optional arguments is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. If _referenceISODay_ is *undefined*, then
           1. Set _referenceISODay_ to *1*<sub>𝔽</sub>.
-        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_, *false*).
-        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_, *false*).
+        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISODay_, *true*).
+        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISODay_).
         1. Return ? CreateTemporalYearMonth(_y_, _m_, _calendar_, _ref_, NewTarget).
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -28,16 +28,16 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) for optional arguments is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. If _referenceISODay_ is *undefined*, then
           1. Set _referenceISODay_ to *1*<sub>𝔽</sub>.
-        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_).
-        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
+        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_, *false*).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_, *false*).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISODay_).
+        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISODay_, *true*).
         1. Return ? CreateTemporalYearMonth(_y_, _m_, _calendar_, _ref_, NewTarget).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Changes:
- Made relevant changes in `ToIntnegerWithTruncation`, `ToPositiveIntegerWithTruncation` and `ToIntegerIfIntegral`. 
- Added an `isOptional` flag to `ToIntegerWithTruncation`, which is a Boolean value that indicates whether the argument passed to `ToIntegerWithTruncation`¸ is optional or not 
- Added true/false to all `ToIntegerWithTruncation` callers

Stuff I am not so sure about:
- CalendarEraYear would never pass `undefined` to `ToIntegerWithTruncation`, so do we pass true or false for `isOptional`?
- PlainYearMonth returns 1 if optional argument _referenceISODay_ is `undefined`.
- ToTemporalPartialDurationRecord throws TypeError for `undefined` values, should it be RangeError instead to make it consistent?


To Do:
- Fix polyfill
- Fix function description