### PR TITLE
Change date AOs to accept mathematical values

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -29,6 +29,119 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-isodatetoepochdays" type="abstract operation">
+    <h1>
+      ISODateToEpochDays (
+        _year_: an integer,
+        _month_: an integer,
+        _date_: an integer,
+      ): an integer
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It calculates a number of days.</dd>
+    </dl>
+    <emu-alg>
+      1. Let _ym_ be _year_ + (floor(_month_) / 12).
+      1. Let _mn_ be _month_ modulo 12.
+      1. Find a time value _t_ such that EpochTimeToEpochYear(_t_) is _ym_, EpochTimeToMonthInYear(_t_) is _mn_, and EpochTimeToDate(_t_) is 1.
+      1. Return ℝ(Day(_t_)) + _date_ - 1.
+    </emu-alg>
+    <emu-note type="editor"> This operation corresponds to ECMA-262 operation MakeDay(_year_, _month_, _date_). It calculates the result in mathematical values instead of Number values. These two operations would be unified when https://github.com/tc39/ecma262/issues/1087 is fixed.</emu-note>
+  </emu-clause>
+
+  <emu-clause id="sec-epochdaystoepochms" type="abstract operation">
+    <h1>
+      EpochDaysToEpochMs (
+        _day_: an integer,
+        _time_: an integer,
+      ): an integer
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It calculates a number of milliseconds.</dd>
+    </dl>
+    <emu-alg>
+      1. Return _day_ × ℝ(msPerDay) + _time_.
+    </emu-alg>
+    <emu-note type="editor"> This operation corresponds to ECMA-262 operation MakeDate(_date_, _time_). It calculates the result in mathematical values instead of Number values. These two operations would be unified when https://github.com/tc39/ecma262/issues/1087 is fixed.</emu-note>
+  </emu-clause>
+
+  <emu-clause id="sec-year-number">
+    <h1>Year Number</h1>
+    <p>ECMAScript uses a proleptic Gregorian calendar to map a day number to a year number and to determine the month and date within that year. In this calendar, leap years are precisely those which are (divisible by 4) and ((not divisible by 100) or (divisible by 400)). The number of days in year number _y_ is therefore defined by</p>
+    <emu-eqn id="eqn-mathematicaldaysinyear" aoid="MathematicalDaysInYear">
+      MathematicalDaysInYear(_y_)
+        = 365 if ((_y_) modulo 4) ≠ 0
+        = 366 if ((_y_) modulo 4) = 0 and ((_y_) modulo 100) ≠ 0
+        = 365 if ((_y_) modulo 100) = 0 and ((_y_) modulo 400) ≠ 0
+        = 366 if ((_y_) modulo 400) = 0
+    </emu-eqn>
+    <p>All non-leap years have 365 days with the usual number of days per month and leap years have an extra day in February. The day number of the first day of year _y_ is given by:</p>
+    <emu-eqn id="eqn-epochdaynumberforyear" aoid="EpochDayNumberForYear">EpochDayNumberForYear(_y_) = 365 × (_y_ - 1970) + floor((_y_ - 1969) / 4) - floor((_y_ - 1901) / 100) + floor((_y_ - 1601) / 400)</emu-eqn>
+    <p>The time of the start of a year is:</p>
+    <emu-eqn id="eqn-epochtimeforyear" aoid="EpochTimeForYear">EpochTimeForYear(_y_) = ℝ(msPerDay) × EpochDayNumberForYear(_y_)</emu-eqn>
+    <p>A time value determines a year by:</p>
+    <emu-eqn id="eqn-epochtimetoepochyear" aoid="EpochTimeToEpochYear">EpochTimeToEpochYear(_t_) = the largest integral Number _y_ (closest to +∞) such that EpochTimeForYear(_y_) ≤ _t_</emu-eqn>
+    <p>The leap-year function is 1 for a time within a leap year and otherwise is 0:</p>
+    <emu-eqn id="eqn-mathematicalinleapyear" aoid="MathematicalInLeapYear">
+      MathematicalInLeapYear(_t_)
+        = 0 if MathematicalDaysInYear(EpochTimeToEpochYear(_t_)) is 365
+        = 1 if MathematicalDaysInYear(EpochTimeToEpochYear(_t_)) is 366
+    </emu-eqn>
+    <emu-note type="editor"> These operations correspond to ECMA-262 operations DaysInYear(_y_), DayFromYear(_y_), TimeFromYear(_y_), YearFromTime(_t_). They calculate the result in mathematical values instead of Number values. These operations would be unified when https://github.com/tc39/ecma262/issues/1087 is fixed.</emu-note>
+  </emu-clause>
+
+  <emu-clause id="sec-month-number">
+    <h1>Month Number</h1>
+    <p>Months are identified by an integer in the inclusive interval from 0 to 11. The mapping EpochTimeToMonthInYear(_t_) from a time value _t_ to a month number is defined by:</p>
+    <emu-eqn id="eqn-epochtimetomonthinyear" aoid="EpochTimeToMonthInYear">
+      EpochTimeToMonthInYear(_t_)
+        = 0 if 0 ≤ EpochTimeToDayInYear(_t_) &lt; 31
+        = 1 if 31 ≤ EpochTimeToDayInYear(_t_) &lt; 59 + MathematicalInLeapYear(_t_)
+        = 2 if 59 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 90 + MathematicalInLeapYear(_t_)
+        = 3 if 90 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 120 + MathematicalInLeapYear(_t_)
+        = 4 if 120 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 151 + MathematicalInLeapYear(_t_)
+        = 5 if 151 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 181 + MathematicalInLeapYear(_t_)
+        = 6 if 181 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 212 + MathematicalInLeapYear(_t_)
+        = 7 if 212 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 243 + MathematicalInLeapYear(_t_)
+        = 8 if 243 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 273 + MathematicalInLeapYear(_t_)
+        = 9 if 273 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 304 + MathematicalInLeapYear(_t_)
+        = 10 if 304 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 334 + MathematicalInLeapYear(_t_)
+        = 11 if 334 + MathematicalInLeapYear(_t_) ≤ EpochTimeToDayInYear(_t_) &lt; 365 + MathematicalInLeapYear(_t_)
+    </emu-eqn>
+    <p>where</p>
+    <emu-eqn id="eqn-epochtimetodayinyear" aoid="EpochTimeToDayInYear">EpochTimeToDayInYear(_t_) = ℝ(Day(_t_)) - EpochDayNumberForYear(EpochTimeToEpochYear(_t_))</emu-eqn>
+    <p>A month value of 0 specifies January; 1 specifies February; 2 specifies March; 3 specifies April; 4 specifies May; 5 specifies June; 6 specifies July; 7 specifies August; 8 specifies September; 9 specifies October; 10 specifies November; and 11 specifies December. Note that <emu-eqn>EpochTimeToMonthInYear(0) = 0</emu-eqn>, corresponding to Thursday, 1 January 1970.</p>
+    <emu-note type="editor"> These operations correspond to ECMA-262 operations MonthFromTime(_t_) and DayWithinYear(_y_). They calculate the result in mathematical values instead of Number values. These operations would be unified when https://github.com/tc39/ecma262/issues/1087 is fixed.</emu-note>
+  </emu-clause>
+  <emu-clause id="sec-date-number">
+    <h1>Date Number</h1>
+    <p>A date number is identified by a mathematical value in the inclusive interval from 1 to 31. The mapping EpochTimeToDate(_t_) from a time value _t_ to a date number is defined by:</p>
+    <emu-eqn id="eqn-epochtimetodate" aoid="EpochTimeToDate">
+      EpochTimeToDate(_t_)
+        = EpochTimeToDayInYear(_t_) + 1 if EpochTimeToMonthInYear(_t_) is 0
+        = EpochTimeToDayInYear(_t_) - 30 if EpochTimeToMonthInYear(_t_) is 1
+        = EpochTimeToDayInYear(_t_) - 58 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 2
+        = EpochTimeToDayInYear(_t_) - 89 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 3
+        = EpochTimeToDayInYear(_t_) - 119 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 4
+        = EpochTimeToDayInYear(_t_) - 150 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 5
+        = EpochTimeToDayInYear(_t_) - 180 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 6
+        = EpochTimeToDayInYear(_t_) - 211 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 7
+        = EpochTimeToDayInYear(_t_) - 242 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 8
+        = EpochTimeToDayInYear(_t_) - 272 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 9
+        = EpochTimeToDayInYear(_t_) - 303 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 10
+        = EpochTimeToDayInYear(_t_) - 333 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 11
+    </emu-eqn>
+    <emu-note type="editor"> This operation corresponds to ECMA-262 operation DateFromTime(_t_). It calculates the result in mathematical values instead of Number values. These operations would be unified when https://github.com/tc39/ecma262/issues/1087 is fixed.</emu-note>
+  </emu-clause>
+  <emu-clause id="sec-week-day">
+    <h1>Week Day</h1>
+    <p>The weekday for a particular time _t_ is defined as</p>
+    <emu-eqn id="eqn-epochtimetoweekday" aoid="EpochTimeToWeekDay">EpochTimeToWeekDay(_t_) =(ℝ(Day(_t_)) + 4) modulo 7</emu-eqn>
+    <p>A weekday value of 0 specifies Sunday; 1 specifies Monday; 2 specifies Tuesday; 3 specifies Wednesday; 4 specifies Thursday; 5 specifies Friday; and 6 specifies Saturday. Note that <emu-eqn>EpochTimeToWeekDay(0) = 4</emu-eqn>, corresponding to Thursday, 1 January 1970.</p>
+    <emu-note type="editor"> This operation corresponds to ECMA-262 operation WeekDay(_t_). It calculates the result in mathematical values instead of Number values. These operations would be unified when https://github.com/tc39/ecma262/issues/1087 is fixed.</emu-note>
+  </emu-clause>
   <!-- Copied from ECMA-402 GetOptionsObject -->
   <emu-clause id="sec-getoptionsobject" aoid="GetOptionsObject">
     <h1>GetOptionsObject ( _options_ )</h1>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -651,7 +651,7 @@
         1. If _month_ is 1, 3, 5, 7, 8, 10, or 12, return 31.
         1. If _month_ is 4, 6, 9, or 11, return 30.
         1. Assert: _month_ is 2.
-        1. Return 28 + ℝ(InLeapYear(TimeFromYear(𝔽(_year_)))).
+        1. Return 28 + MathematicalInLeapYear(EpochTimeForYear(_year_)).
       </emu-alg>
     </emu-clause>
 
@@ -683,11 +683,11 @@
           1. Let _dayOfJan1st_ be ToISODayOfWeek(_year_, 1, 1).
           1. If _dayOfJan1st_ is _friday_, then
             1. Return the Year-Week Record { [[Week]]: _maxWeekNumber_, [[Year]]: _year_ - 1 }.
-          1. If _dayOfJan1st_ is _saturday_, and InLeapYear(TimeFromYear(𝔽(_year_ - 1))) is *1*<sub>𝔽</sub>, then
+          1. If _dayOfJan1st_ is _saturday_, and MathematicalInLeapYear(EpochTimeForYear(_year_ - 1)) is 1, then
             1. Return the Year-Week Record { [[Week]]: _maxWeekNumber_. [[Year]]: _year_ - 1 }.
           1. Return the Year-Week Record { [[Week]]: _maxWeekNumber_ - 1, [[Year]]: _year_ - 1 }.
         1. If _week_ is _maxWeekNumber_, then
-          1. Let _daysInYear_ be DaysInYear(𝔽(_year_)).
+          1. Let _daysInYear_ be MathematicalDaysInYear(_year_).
           1. Let _daysLaterInYear_ be _daysInYear_ - _dayOfYear_.
           1. Let _daysAfterThursday_ be _thursday_ - _dayOfWeek_.
           1. If _daysLaterInYear_ &lt; _daysAfterThursday_, then
@@ -844,9 +844,8 @@
       </dl>
       <emu-alg>
         1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
-        1. Let _epochDays_ be MakeDay(𝔽(year), 𝔽(month - 1), 𝔽(day)).
-        1. Assert: _epochDays_ is finite.
-        1. Return ℝ(DayWithinYear(MakeDate(_epochDays_, *+0*<sub>𝔽</sub>))) + 1.
+        1. Let _epochDays_ be ISODateToEpochDays(year, month - 1, day).
+        1. Return EpochTimeToDayInYear(EpochDaysToEpochMs(_epochDays_, 0)) + 1.
       </emu-alg>
     </emu-clause>
 
@@ -864,11 +863,10 @@
       </dl>
       <emu-alg>
         1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
-        1. Let _epochDays_ be MakeDay(𝔽(year), 𝔽(month - 1), 𝔽(day)).
-        1. Assert: _epochDays_ is finite.
-        1. Let _dayOfWeek_ be WeekDay(MakeDate(_epochDays_, *+0*<sub>𝔽</sub>)).
-        1. If _dayOfWeek_ = *+0*<sub>𝔽</sub>, return 7.
-        1. Return ℝ(_dayOfWeek_).
+        1. Let _epochDays_ be ISODateToEpochDays(year, month - 1, day).
+        1. Let _dayOfWeek_ be EpochTimeToWeekDay(EpochDaysToEpochMs(_epochDays_, 0)).
+        1. If _dayOfWeek_ = 0, return 7.
+        1. Return _dayOfWeek_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -1294,7 +1292,7 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. Return DaysInYear(𝔽(_temporalDateLike_.[[ISOYear]])).
+        1. Return 𝔽(MathematicalDaysInYear(_temporalDateLike_.[[ISOYear]])).
       </emu-alg>
     </emu-clause>
 
@@ -1332,7 +1330,7 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. If InLeapYear(TimeFromYear(𝔽(_temporalDateLike_.[[ISOYear]]))) is *1*<sub>𝔽</sub>, return *true*.
+        1. If MathematicalInLeapYear(EpochTimeForYear(_temporalDateLike_.[[ISOYear]])) is 1, return *true*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1549,11 +1549,9 @@
         If _earlier_ is later than _later_, then the result is negative.</dd>
       </dl>
       <emu-alg>
-        1. Let _epochDays1_ be MakeDay(𝔽(_earlier_.[[ISOYear]]), 𝔽(_earlier_.[[ISOMonth]] - 1), 𝔽(_earlier_.[[ISODay]])).
-        1. Assert: _epochDays1_ is finite.
-        1. Let _epochDays2_ be MakeDay(𝔽(_later_.[[ISOYear]]), 𝔽(_later_.[[ISOMonth]] - 1), 𝔽(_later_.[[ISODay]])).
-        1. Assert: _epochDays2_ is finite.
-        1. Return ℝ(_epochDays2_) - ℝ(_epochDays1_).
+        1. Let _epochDays1_ be ISODateToEpochDays(_earlier_.[[ISOYear]], _earlier_.[[ISOMonth]] - 1, _earlier_.[[ISODay]]).
+        1. Let _epochDays2_ be ISODateToEpochDays(_later_.[[ISOYear]], _later_.[[ISOMonth]] - 1, _later_.[[ISODay]]).
+        1. Return _epochDays2_ - _epochDays1_.
       </emu-alg>
     </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1033,14 +1033,7 @@
             </td>
           </tr>
           <tr>
-            <td>[[RelatedYear]]</td>
-            <td>*undefined*</td>
-          </tr>
-          <tr>
-            <td>[[YearName]]</td>
-            <td>*undefined*</td>
-          </tr>
-          <tr>
+          <h1>ToLocalTime ( _t_, _calendar_, _timeZone_ )</h1>
             <td>[[Month]]</td>
             <td>
               <del>`MonthFromTime(tz)` specified in ES2023's <emu-xref href="#sec-month-number">Month Number</emu-xref></del>
@@ -2172,7 +2165,7 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Return DaysInYear(𝔽(_temporalDateLike_.[[ISOYear]])).
+              1. Return 𝔽(MathematicalDaysInYear(_temporalDateLike_.[[ISOYear]])).
             1. Let _daysInYear_ be ! CalendarDateDaysInYear(_calendar_.[[Identifier]], _temporalDateLike_).
             1. Return 𝔽(_daysInYear_).
           </emu-alg>
@@ -2209,7 +2202,7 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. If InLeapYear(TimeFromYear(𝔽(_temporalDateLike_.[[ISOYear]]))) is *1*<sub>𝔽</sub>, then
+              1. If MathematicalInLeapYear(EpochTimeForYear(_temporalDateLike_.[[ISOYear]])) is 1, then
                 1. Let _inLeapYear_ be *true*.
               1. Else,
                 1. Let _inLeapYear_ be *false*.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -809,11 +809,9 @@
           1. Return ! CreateDateDurationRecord(_years_, _months_, 0, _days_).
         1. Else,
           1. Assert: _largestUnit_ is *"day"* or *"week"*.
-          1. Let _epochDays1_ be MakeDay(𝔽(_y1_), 𝔽(_m1_ - 1), 𝔽(_d1_)).
-          1. Assert: _epochDays1_ is finite.
-          1. Let _epochDays2_ be MakeDay(𝔽(_y2_), 𝔽(_m2_ - 1), 𝔽(_d2_)).
-          1. Assert: _epochDays2_ is finite.
-          1. Let _days_ be ℝ(_epochDays2_) - ℝ(_epochDays1_).
+          1. Let _epochDays1_ be ISODateToEpochDays(_y1_, _m1_ - 1, _d1_).
+          1. Let _epochDays2_ be ISODateToEpochDays(_y2_, _m2_ - 1, _d2_).
+          1. Let _days_ be _epochDays2_ - _epochDays1_.
           1. Let _weeks_ be 0.
           1. If _largestUnit_ is *"week"*, then
             1. Set _weeks_ to truncate(_days_ / 7).
@@ -891,10 +889,9 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _epochDays_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
-        1. Assert: _epochDays_ is finite.
-        1. Let _ms_ be MakeDate(_epochDays_, *+0*<sub>𝔽</sub>).
-        1. Return CreateISODateRecord(ℝ(YearFromTime(_ms_)), ℝ(MonthFromTime(_ms_)) + 1, ℝ(DateFromTime(_ms_))).
+        1. Let _epochDays_ be ISODateToEpochDays(_year_, _month_ - 1, _day_).
+        1. Let _ms_ be EpochDaysToEpochMs(_epochDays_, 0).
+        1. Return CreateISODateRecord(EpochTimeToEpochYear(_ms_), EpochTimeToMonthInYear(_ms_) + 1, EpochTimeToDate(_ms_)).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -420,9 +420,9 @@
         1. Assert: ! IsValidEpochNanoseconds(ℤ(_epochNanoseconds_)) is *true*.
         1. Let _remainderNs_ be _epochNanoseconds_ modulo 10<sup>6</sup>.
         1. Let _epochMilliseconds_ be 𝔽((_epochNanoseconds_ - _remainderNs_) / 10<sup>6</sup>).
-        1. Let _year_ be ℝ(! YearFromTime(_epochMilliseconds_)).
-        1. Let _month_ be ℝ(! MonthFromTime(_epochMilliseconds_)) + 1.
-        1. Let _day_ be ℝ(! DateFromTime(_epochMilliseconds_)).
+        1. Let _year_ be ! EpochTimeToEpochYear(_epochMilliseconds_).
+        1. Let _month_ be ! EpochTimeToMonthInYear(_epochMilliseconds_) + 1.
+        1. Let _day_ be ! EpochTimeToDate(_epochMilliseconds_).
         1. Let _hour_ be ℝ(! HourFromTime(_epochMilliseconds_)).
         1. Let _minute_ be ℝ(! MinFromTime(_epochMilliseconds_)).
         1. Let _second_ be ℝ(! SecFromTime(_epochMilliseconds_)).


### PR DESCRIPTION
I have kept the names same as the original methods, but I believe they'll have to be changed, also under what section do we define these? 